### PR TITLE
Make the code build with more recent ESP SDK versions.

### DIFF
--- a/driver/easygpio/easygpio.c
+++ b/driver/easygpio/easygpio.c
@@ -120,18 +120,19 @@ easygpio_getGPIONameFunc(uint8_t gpio_pin, uint32_t *gpio_name, uint8_t *gpio_fu
 /**
  * Sets the pull up and pull down registers for a pin.
  * 'pullUp' takes precedence over pullDown
+ *
+ * Note that there is no pulldown functionality on the ESP8266 - you need to use
+ * an external pulldown resistor. The asssociated functions have been removed from
+ * the SDK starting with SDK version 1.1.0_15_05_26
  */
 static void ICACHE_FLASH_ATTR
 easygpio_setupPullsByName(uint32_t gpio_name, EasyGPIO_PullStatus pullStatus) {
 
   if (EASYGPIO_PULLUP == pullStatus){
-    PIN_PULLDWN_DIS(gpio_name);
     PIN_PULLUP_EN(gpio_name);
   } else if (EASYGPIO_PULLDOWN == pullStatus){
     PIN_PULLUP_DIS(gpio_name);
-    PIN_PULLDWN_EN(gpio_name);
   } else {
-    PIN_PULLDWN_DIS(gpio_name);
     PIN_PULLUP_DIS(gpio_name);
   }
 }

--- a/user/user_main.c
+++ b/user/user_main.c
@@ -50,7 +50,15 @@ setup(void) {
   os_timer_arm(&loop_timer, PING_SAMPLE_PERIOD, true);
 }
 
-//Init function 
+/**
+ * ESP SDK V1.1.0 introduced a new user init callback for RF settings.
+ * This optional function must be present for SDK 1.1.0 and 1.2.0,
+ * In 1.3.0, it can be removed.
+ */
+void user_rf_pre_init(void)
+{
+}
+//Init function
 void ICACHE_FLASH_ATTR
 user_init(void) {
   // Make uart0 work with just the TX pin. Baud:115200,n,8,1


### PR DESCRIPTION
Hi,

I was about to write my own driver for an HC-SR04 sensor module when I came across yours :+1: )

My sensor is connected through level converters to GPIO4/5 on an ESP-07 module.

Seems to work just fine, distance is off (too short) by about 10mm when measured from the front of the sensor.

I've made a couple minor tweaks so the code builds on the more recent ESP SDKs (0.9.5 - 1.3.0)

Regards,
Marc

marc@o ~/ESPRESSIF/github/esp8266_ping $ for SDK in /opt/Espressif/esp_iot_sdk_v*; do echo $SDK; make clean; export SDK_BASE=$SDK; make && echo OK USING $SDK; done | grep OK
OK USING /opt/Espressif/esp_iot_sdk_v0.9.5
OK USING /opt/Espressif/esp_iot_sdk_v1.1.0
OK USING /opt/Espressif/esp_iot_sdk_v1.1.1
OK USING /opt/Espressif/esp_iot_sdk_v1.2.0
OK USING /opt/Espressif/esp_iot_sdk_v1.3.0
